### PR TITLE
Invalid index access

### DIFF
--- a/EmojicodeCompiler/StaticAnalyzer.cpp
+++ b/EmojicodeCompiler/StaticAnalyzer.cpp
@@ -206,7 +206,7 @@ void analyzeClassesAndWrite(FILE *fout){
     
     Package *pkg = nullptr;
     Class *eclass;
-    for (size_t i = 0; eclass = classes[i], i < classes.size(); i++) {
+    for (size_t i = 0; (i < classes.size()) && (eclass = classes[i]); i++) {
         if((pkg != eclass->package && pkgCount > 1) || !pkg){ //pkgCount > 1: Ignore the second s
             if (i > 0){
                 writer.writeByte(0);


### PR DESCRIPTION
The index of classes is being accessed in the assignment expression
before the constraint is checked that such an index is valid. This can result in an out of range index being accessed and causing program termination.
