### PR TITLE
👷 Fix Include Statement

### DIFF
--- a/EmojicodeCompiler/FileParser.cpp
+++ b/EmojicodeCompiler/FileParser.cpp
@@ -539,16 +539,19 @@ void parseFile(const char *path, Package *pkg){
                 
                 auto fileString = pathString->value.utf8CString();
                 
-                char *str = fileString;
+                char *str;
                 const char *lastSlash = strrchr(path, '/');
-                if (lastSlash != nullptr) {
+                if (lastSlash == nullptr) {
+                    asprintf(&str, "%s", fileString);
+                }
+                else {
                     const char *directory = strndup(path, lastSlash - path);
                     asprintf(&str, "%s/%s", directory, fileString);
                 }
+                delete [] fileString;
                 
                 parseFile(str, pkg);
-                
-                delete [] fileString;
+
                 delete [] str;
                 continue;
             }

--- a/EmojicodeCompiler/FileParser.cpp
+++ b/EmojicodeCompiler/FileParser.cpp
@@ -539,12 +539,9 @@ void parseFile(const char *path, Package *pkg){
                 
                 auto fileString = pathString->value.utf8CString();
                 
-                char *str;
+                char *str = fileString;
                 const char *lastSlash = strrchr(path, '/');
-                if (lastSlash == nullptr) {
-                    asprintf(&str, "%s", fileString);
-                }
-                else {
+                if (lastSlash != nullptr) {
                     const char *directory = strndup(path, lastSlash - path);
                     asprintf(&str, "%s/%s", directory, fileString);
                 }
@@ -552,6 +549,7 @@ void parseFile(const char *path, Package *pkg){
                 parseFile(str, pkg);
                 
                 delete [] fileString;
+                delete [] str;
                 continue;
             }
             default:

--- a/EmojicodeCompiler/FileParser.cpp
+++ b/EmojicodeCompiler/FileParser.cpp
@@ -539,16 +539,13 @@ void parseFile(const char *path, Package *pkg){
                 
                 auto fileString = pathString->value.utf8CString();
                 
-                char *str;
+                char *str = fileString;
                 const char *lastSlash = strrchr(path, '/');
-                if (lastSlash == nullptr) {
-                    asprintf(&str, "%s", fileString);
-                }
-                else {
+                if (lastSlash != nullptr) {
                     const char *directory = strndup(path, lastSlash - path);
                     asprintf(&str, "%s/%s", directory, fileString);
+                    delete [] fileString;
                 }
-                delete [] fileString;
                 
                 parseFile(str, pkg);
 

--- a/EmojicodeCompiler/FileParser.cpp
+++ b/EmojicodeCompiler/FileParser.cpp
@@ -539,11 +539,15 @@ void parseFile(const char *path, Package *pkg){
                 
                 auto fileString = pathString->value.utf8CString();
                 
-                const char *lastSlash = strrchr(path, '/');
-                const char *directory = strndup(path, lastSlash - path);
-            
                 char *str;
-                asprintf(&str, "%s/%s", directory, fileString);
+                const char *lastSlash = strrchr(path, '/');
+                if (lastSlash == nullptr) {
+                    asprintf(&str, "%s", fileString);
+                }
+                else {
+                    const char *directory = strndup(path, lastSlash - path);
+                    asprintf(&str, "%s/%s", directory, fileString);
+                }
                 
                 parseFile(str, pkg);
                 


### PR DESCRIPTION
Before this change, when the source files that were passed onto the
compiler were in the current directory (without a slash in the path)
the compiler would do some weird stuff. This should fix that.
