### PR TITLE
Keycap Emoji Characters Fix

### DIFF
--- a/EmojicodeCompiler/Lexer.cpp
+++ b/EmojicodeCompiler/Lexer.cpp
@@ -61,7 +61,7 @@ TokenStream lex(const char *path) {
         throw CompilerErrorException(sourcePosition, "Cannot allocate buffer for file %s. It is possibly to large.", path);
     }
     
-#define isIdentifier() ((0x1F300 <= c && c <= 0x1F64F) || (0x1F680 <= c && c <= 0x1F6C5) || (0x1F6CB <= c && c <= 0x1F6F3) || (0x2600 <= c && c <= 0x27BF) || (0x1F191 <= c && c <= 0x1F19A) || c == 0x231A || (0x1F910 <= c && c <= 0x1F9C0) || (0x2B00 <= c && c <= 0x2BFF) || (0x25A0 <= c && c <= 0x25FF) || (0x2300 <= c && c <= 0x23FF) || (0x2190 <= c && c <= 0x21FF))
+#define isIdentifier() ((0x1F300 <= c && c <= 0x1F64F) || (0x1F680 <= c && c <= 0x1F6C5) || (0x1F6CB <= c && c <= 0x1F6F3) || (0x2600 <= c && c <= 0x27BF) || (0x1F191 <= c && c <= 0x1F19A) || c == 0x231A || (0x1F910 <= c && c <= 0x1F9C0) || (0x2B00 <= c && c <= 0x2BFF) || (0x25A0 <= c && c <= 0x25FF) || (0x2300 <= c && c <= 0x23FF) || (0x2190 <= c && c <= 0x21FF) || (c == 0x2139) || (0x2934 <= c && c <= 0x2935))
     
     while (i < length) {
         size_t delta = i;

--- a/EmojicodeCompiler/Lexer.cpp
+++ b/EmojicodeCompiler/Lexer.cpp
@@ -46,7 +46,7 @@ TokenStream lex(const char *path) {
     bool oneLineComment = false;
     bool isHex = false;
     bool escapeSequence = false;
-	bool possiblyIdentifier = false;
+    bool possiblyIdentifier = false;
     
     fseek(f, 0, SEEK_END);
     long length = ftell(f);
@@ -143,29 +143,29 @@ TokenStream lex(const char *path) {
                         /* End of variable */
                         nextToken = true;
                     }
-					else if (c == 0xFE0F) {
-						// Variation Selector 16
-						possiblyIdentifier = true;
-						continue;
-					}
-					else if (possiblyIdentifier) {
-						if (c == 0x20E3) {
-							// COMBINING ENCLOSING KEYCAP: This is a keycap emoji
-							auto first = token->value[0];
-							token->value.clear();
-							token->value.push_back(first);
-							token->type_ = TokenType::Identifier;
-							nextToken = true;
-							continue;
-						}
-						else {
-							// There was just a misplaced Variation Selector, delete and move on
-							possiblyIdentifier = false;
-							token->value.pop_back();
-							token->value.push_back(c);
-							continue;
-						}
-					}
+                    else if (c == 0xFE0F) {
+                        // Variation Selector 16
+                        possiblyIdentifier = true;
+                        continue;
+                    }
+                    else if (possiblyIdentifier) {
+                        if (c == 0x20E3) {
+                            // COMBINING ENCLOSING KEYCAP: This is a keycap emoji
+                            auto first = token->value[0];
+                            token->value.clear();
+                            token->value.push_back(first);
+                            token->type_ = TokenType::Identifier;
+                            nextToken = true;
+                            continue;
+                        }
+                        else {
+                            // There was just a misplaced Variation Selector, delete and move on
+                            possiblyIdentifier = false;
+                            token->value.pop_back();
+                            token->value.push_back(c);
+                            continue;
+                        }
+                    }
                     else {
                         token->value.push_back(c);
                         continue;
@@ -190,29 +190,29 @@ TokenStream lex(const char *path) {
                     else if (c == '_') {
                         continue;
                     }
-					else if (c == 0xFE0F) {
-						// Variation Selector 16
-						possiblyIdentifier = true;
-						continue;
-					}
-					else if (possiblyIdentifier) {
-						if (c == 0x20E3) {
-							// COMBINING ENCLOSING KEYCAP: This is a keycap emoji
-							auto first = token->value[0];
-							token->value.clear();
-							token->value.push_back(first);
-							token->type_ = TokenType::Identifier;
-							nextToken = true;
-							continue;
-						}
-						else {
-							// There was just a misplaced Variation Selector, delete and move on
-							possiblyIdentifier = false;
-							token->value.pop_back();
-							token->value.push_back(c);
-							continue;
-						}
-					}
+                    else if (c == 0xFE0F) {
+                        // Variation Selector 16
+                        possiblyIdentifier = true;
+                        continue;
+                    }
+                    else if (possiblyIdentifier) {
+                        if (c == 0x20E3) {
+                            // COMBINING ENCLOSING KEYCAP: This is a keycap emoji
+                            auto first = token->value[0];
+                            token->value.clear();
+                            token->value.push_back(first);
+                            token->type_ = TokenType::Identifier;
+                            nextToken = true;
+                            continue;
+                        }
+                        else {
+                            // There was just a misplaced Variation Selector, delete and move on
+                            possiblyIdentifier = false;
+                            token->value.pop_back();
+                            token->value.push_back(c);
+                            continue;
+                        }
+                    }
                     else {
                         token->validateInteger(isHex);
                         // An unexpected character, seems to be a new token
@@ -263,7 +263,7 @@ TokenStream lex(const char *path) {
             token->value.push_back(c);
             
             isHex = false;
-			possiblyIdentifier = false;
+            possiblyIdentifier = false;
         }
         else if (c == E_THUMBS_UP_SIGN || c == E_THUMBS_DOWN_SIGN) {
             token->type_ = (c == E_THUMBS_UP_SIGN) ? TokenType::BooleanTrue : TokenType::BooleanFalse;
@@ -288,8 +288,8 @@ TokenStream lex(const char *path) {
         else {
             token->type_ = TokenType::Variable;
             token->value.push_back(c);
-			
-			possiblyIdentifier = false;
+            
+            possiblyIdentifier = false;
         }
     }
     delete [] stringBuffer;

--- a/EmojicodeCompiler/Lexer.cpp
+++ b/EmojicodeCompiler/Lexer.cpp
@@ -160,12 +160,15 @@ TokenStream lex(const char *path) {
                         /* End of variable */
                         nextToken = true;
                     }
+                    else if (checkForVS16(c)) {
+                        possiblyIdentifier = true;
+                        continue;
+                    }
                     else if (possiblyIdentifier) {
                         checkAndConvertIfIdentifier();
                         continue;
                     }
                     else {
-                        possiblyIdentifier = checkForVS16(c);
                         token->value.push_back(c);
                         continue;
                     }


### PR DESCRIPTION
(Hopefully) fixes #49. Tested somewhat, haven't found anything wrong.

The multi-character keycap emoji, when converted to identifiers, only use the first character in specifying that emoji. For example, '#️⃣' when used as a type name will be converted to an Identifier called just '#'. This doesn't seem to cause any problems.

Also added more symbols as valid identifiers, because they can appear as emoji in Apple Colour Emoji. This has the same effect as the first change: enabling more Apple Color Emoji emoji to be used as identifiers without random errors.
