### PR TITLE
Adding Dockerfile for Emojicode building environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .git
+build/
 LICENSE
 README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:18.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y wget gnupg
+
+RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-6.0 main" >> /etc/apt/sources.list
+RUN echo "deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-6.0 main" >> /etc/apt/sources.list
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+
+RUN apt-get update && apt-get install -y \
+    clang-6.0 \
+    cmake \
+    libclang-common-6.0-dev \
+    libclang1-6.0 \
+    libclang-6.0-dev \
+    libfuzzer-6.0-dev \
+    libllvm6.0 \
+    libncurses-dev \
+    libz-dev \
+    llvm-6.0 \
+    llvm-6.0-dev \
+    llvm-6.0-runtime \
+    ninja-build \
+    python3 \
+    rsync
+
+RUN mkdir -p /usr/src/emojicode
+WORKDIR /usr/src/emojicode
+COPY . .
+
+ENV CC clang-6.0
+ENV CXX clang++-6.0
+ENV PYTHONIOENCODING utf8
+
+RUN cmake . -GNinja && ninja && ninja magicinstall
+
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:18.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Set locale to en_US.UTF-8
+RUN apt-get update && apt-get install locales
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+# LLVM toolchain
+RUN apt-get update && apt-get install -y wget gnupg && \
+    echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-6.0 main" >> /etc/apt/sources.list && \
+    echo "deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-6.0 main" >> /etc/apt/sources.list && \
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+
+# Dependencies
+RUN apt-get update && apt-get install -y \
+    clang-6.0 \
+    cmake \
+    libclang-common-6.0-dev \
+    libclang1-6.0 \
+    libclang-6.0-dev \
+    libfuzzer-6.0-dev \
+    libllvm6.0 \
+    libncurses-dev \
+    libz-dev \
+    llvm-6.0 \
+    llvm-6.0-dev \
+    llvm-6.0-runtime \
+    ninja-build \
+    python3 \
+    rsync
+
+# Copy source
+RUN mkdir -p /usr/src/emojicode
+WORKDIR /usr/src/emojicode
+COPY . .
+
+# Build
+RUN mkdir build
+WORKDIR build
+ENV CC clang-6.0
+ENV CXX clang++-6.0
+ENV PYTHONIOENCODING utf-8
+RUN cmake .. -GNinja && ninja && ninja magicinstall

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We highly recommend to follow Emojicode’s Twitter account [@Real\_Emojicode][6
 
 ## 🔨 Building from source
 
-### Building locally
+### 🏡 Building locally
 
 Prerequisites (versions are recommendations):
 
@@ -69,6 +69,50 @@ Steps:
    To create a distribution archive you must call the dist script yourself
    (e.g. `python3 ../dist.py .. archive`).
 
+### 🐋 Building using Docker
+
+A `Dockerfile` is available for building in a Ubuntu `18.04` environment.
+
+Steps:
+
+1. Clone Emojicode (or download the source code and extract it) and navigate
+  into it:
+
+   ```sh
+   git clone https://github.com/emojicode/emojicode
+   cd emojicode
+   ```
+
+2. Build Docker image:
+
+   ```sh
+   docker build -t emojicode-build:latest .
+   ```
+
+3. Verify the installation was fine:
+
+   ```
+   ...
+   ✅  Emojicode was successfully installed.
+   ```
+
+4. Start image (and mount a directory to it):
+
+   ```sh
+   docker run -v $(pwd)/code:/workspace -it emojicode-build:latest
+   ```
+
+5. Start image (and mount a directory to it):
+
+   ```sh
+   docker run -v $(pwd)/code:/workspace -it emojicode-build:latest
+   ```
+
+6. Start coding !
+
+   ```sh
+   emojicodec /workspace/hello.🍇 && . /workspace/hello
+   ```
 
 ## 📃 License
 


### PR DESCRIPTION
Changes made :
 - add `Dockerfile` which will build Emojicode for Ubuntu `18.04` ;
 - update `README.md` and add `Build with Docker` section.