### PR TITLE
⚡ Prevent stages beyond parsing when formatting

### DIFF
--- a/Compiler/CLI/main.cpp
+++ b/Compiler/CLI/main.cpp
@@ -44,6 +44,7 @@ bool start(const Options &options) {
     compiler.add<Compiler::ParsePhase>();
     if (options.prettyprint()) {
         compiler.add<FormatPhase>();
+        return compiler.compile();
     }
     compiler.add<Compiler::AnalysisPhase>(options.standalone());
     if (!options.interfaceFile().empty()) {


### PR DESCRIPTION
Resolves #178 

***

I apologize if this is an overly simple solution, but it seemed to me that, if formatting the code is the user's goal, that no other phases should be performed (except maybe the analysis phase :thinking: ). Please let me know if the more changes should be made :smiley: