### PR TITLE
:mouse: Add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+end_of_line = LF
+indent_style = space
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{c,h}]
+indent_size = 2
+
+[*.{cpp,hpp,py}]
+indent_size = 4
+
+[*.{emojic,🍇}]
+indent_size = 2


### PR DESCRIPTION
I noticed there wasn't an [`.editorconfig`](https://editorconfig.org/) file, which can be used to keep behavior consistent among editors (my editor was defaulting to tab indentation).