### PR TITLE
Inform linguist about dockerfile(s)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docker/* linguist-language=Dockerfile


### PR DESCRIPTION
This should adjust search results, language statistics, and fix syntax highlighting. This probably won't happen immediately due to GitHub's indexing and caching.

It seemed to me to be a reasonable assumption that all files in `docker/` would be Dockerfiles.